### PR TITLE
Safely return even if the object structure doesn't match

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,10 @@ class LgRemote {
     xml2js.parseString(await response.text(), (err, text) => {
       content = text;
     });
-    return content.envelope.device[0];
+    
+    // Safely return a deeply-nested value because the || operator
+    // return the second parameter if the first parameter is falsy.
+    return (((content || {}).envelope || {}).device || {})[0];
   }
 
   // Scan for devices on localhost


### PR DESCRIPTION
Indirectly relates to #1 

Fixes uncaught exceptions that occurred when the response to `getDescription()` does not match the expected structure, e.g. Philips Hue hub responds to the very same UDAP service (`urn:schemas-udap:service:netrcu:1`) 6 times in a row but it's response to the "description" query is very different from LG's. 